### PR TITLE
Remove file extension from href's

### DIFF
--- a/jquery.activeNavigation.js
+++ b/jquery.activeNavigation.js
@@ -1,10 +1,17 @@
 (function( $ ) {
     $.fn.activeNavigation = function(selector) {
         var pathname = window.location.pathname
+        var extension_position;
+        var href;
         var hrefs = []
         $(selector).find("a").each(function(){
-            if (pathname.indexOf($(this).attr("href")) > -1) 
-                hrefs.push($(this))
+            // Remove href file extension
+            extension_position = $(this).attr("href").lastIndexOf('.');
+            href = (extension_position >= 0) ? $(this).attr("href").substr(0, extension_position) : $(this).attr("href");
+
+            if (pathname.indexOf(href) > -1) {
+                hrefs.push($(this));
+            }
         })
         if (hrefs.length) {
             hrefs.sort(function(a,b){


### PR DESCRIPTION
So you can mix a menu with file extensions with subdirs.

Example:

``` html
<menu id="nav"> 
  <ul>
    <li><a href="/">Home</a></li>
    <li><a href="/about.html">About</a></li>
    <li><a href="/clients.html">Clients</a></li>
    <li><a href="/contact.html">Contact Us</a></li>
  </ul>
</menu>
```

Will set "active" for About for url "/about/file.html"
